### PR TITLE
Update ssh local port and add qrstat --available=

### DIFF
--- a/v3/en/docs/getting-started.md
+++ b/v3/en/docs/getting-started.md
@@ -30,10 +30,10 @@ In this section, we will describe two methods to login to the interactive node u
 
 #### General method
 
-Login to the access server (*as.v3.abci.ai*) with following command:
+Login to the access server (*as.v3.abci.ai*) with following command. As an example, port number 50022 is used for the connection. However, if this port is already being used for connections to other hosts (such as ABCI2.0) or if the originating terminal is using this port for another service, causing a conflict, please change to a different port number.
 
 ```
-[yourpc ~]$ ssh -i /path/identity_file -L 10022:login:22 -l username as.v3.abci.ai
+[yourpc ~]$ ssh -i /path/identity_file -L 50022:login:22 -l username as.v3.abci.ai
 The authenticity of host 'as.v3.abci.ai (0.0.0.1)' can't be established.
 RSA key fingerprint is XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX. <- Display only at the first login
 Are you sure you want to continue connecting (yes/no)? <- Enter "yes"
@@ -55,7 +55,7 @@ Please press any key if you disconnect this session.
 Launch another terminal and login to the interactive node using the SSH tunnel:
 
 ```
-[yourpc ~]$ ssh -i /path/identity_file -p 10022 -l username localhost
+[yourpc ~]$ ssh -i /path/identity_file -p 50022 -l username localhost
 The authenticity of host 'localhost (127.0.0.1)' can't be established.
 RSA key fingerprint is XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX. <- Display only at the first login
 Are you sure you want to continue connecting (yes/no)? <- Enter "yes"
@@ -106,7 +106,7 @@ Host as.v3.abci.ai
 When you transfer files between your computer and the ABCI system, create an SSH tunnel and run the `scp` (`sftp`) command.
 
 ```
-[yourpc ~]$ scp -P 10022 local-file username@localhost:remote-dir
+[yourpc ~]$ scp -P 50022 local-file username@localhost:remote-dir
 Enter passphrase for key: <- Enter passphrase
     
 local-file    100% |***********************|  file-size  transfer-time

--- a/v3/en/docs/job-execution.md
+++ b/v3/en/docs/job-execution.md
@@ -317,11 +317,11 @@ Standard output file and standard error output file are written to job execution
 Standard output generated during a job execution is written to a standard output file and error messages generated during the
 job execution to a standard error output file if no standard output and standard err output files are specified at job submission,
 the following files are generated for output.
+Additionally, the output file will be created after the job completes.
 
 - *JOB_NAME*.o*NUM_JOB_ID*  ---  Standard output file
 - *JOB_NAME*.e*NUM_JOB_ID*  ---  Standard error output file
 
-Additionally, the output file will be created after the job completes.
 
 ## Environment Variables
 
@@ -421,6 +421,18 @@ R1234.pbs1      R1234         usrname  RN            Wed 10:40 / 1506000 / Sat F
 | Start | Start reservation date (start time is 10:00 a.m. at all time) |
 | Duration | Reservation term (seconds) |
 | End | End reservation date (end time is 9:30 a.m. at all time) |
+
+To check the number of reservable nodes per group, specify the group name with the `--available=grpname` option of the `qrstat` command and execute it.
+
+Example) Check the number of reservable nodes per group
+```
+[username@login1 ~]$ qrstat --available=grpname
+date       available nodes for group
+---------- -------------------------
+01/30/2025                       192
+01/31/2025                       192
+```
+
 
 ### Cancel a reservation
 

--- a/v3/ja/docs/getting-started.md
+++ b/v3/ja/docs/getting-started.md
@@ -30,10 +30,10 @@ ABCIシステムのフロントエンドであるインタラクティブノー�
 
 #### 一般的なログイン方法 {#general-method}
 
-以下のコマンドでアクセスサーバ(*as.v3.abci.ai*)にログインし、SSHトンネルを作成します。
+以下のコマンドでアクセスサーバ(*as.v3.abci.ai*)にログインし、SSHトンネルを作成します。接続例としてポート番号を50022としていますが、既に他のホスト(ABCI2.0など)への接続において使用している場合や接続元の端末が何らかのサービスで該当ポートを使用しており競合が発生した場合には他のポート番号に変更して下さい。
 
 ```
-[yourpc ~]$ ssh -i /path/identity_file -L 10022:login:22 -l username as.v3.abci.ai
+[yourpc ~]$ ssh -i /path/identity_file -L 50022:login:22 -l username as.v3.abci.ai
 The authenticity of host 'as.v3.abci.ai (0.0.0.1)' can't be established.
 RSA key fingerprint is XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX. <- 初回ログイン時のみ表示
 Are you sure you want to continue connecting (yes/no)?  <- yesを入力
@@ -55,7 +55,7 @@ Please press any key if you disconnect this session.
 続いて、別のターミナルを起動し、SSHトンネルを用いてインタラクティブノードにログインします。
 
 ```
-[yourpc ~]$ ssh -i /path/identity_file -p 10022 -l username localhost
+[yourpc ~]$ ssh -i /path/identity_file -p 50022 -l username localhost
 The authenticity of host 'localhost (127.0.0.1)' can't be established.
 RSA key fingerprint is XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX. <- 初回ログイン時のみ表示
 Are you sure you want to continue connecting (yes/no)? <- yesを入力
@@ -108,7 +108,7 @@ Host as.v3.abci.ai
 SSHトンネルの設定後、以下のように実行します。
 
 ```
-[yourpc ~]$ scp -i /path/identity_file -P 10022 local-file username@localhost:remote-dir
+[yourpc ~]$ scp -i /path/identity_file -P 50022 local-file username@localhost:remote-dir
 Enter passphrase for key: <- パスフレーズを入力
     
 local-file    100% |***********************|  file-size  transfer-time

--- a/v3/ja/docs/job-execution.md
+++ b/v3/ja/docs/job-execution.md
@@ -319,6 +319,7 @@ Job id                 Name             User              Time Use S Queue
 ジョブ投入時に指定されたファイルに出力されます。
 標準出力ファイルにはジョブ実行中の標準出力、標準エラー出力ファイルにはジョブ実行中のエラーメッセージが出力されます。
 ジョブ投入時に、標準出力ファイル、標準エラー出力ファイルを指定しなかった場合は、以下のファイルに出力されます。
+また、出力ファイルはジョブ終了後に作成されます。
 
 - *JOB_NAME*.o*NUM_JOB_ID*  ---  標準出力ファイル
 - *JOB_NAME*.e*NUM_JOB_ID*  ---  標準エラー出力ファイル
@@ -328,7 +329,6 @@ Job id                 Name             User              Time Use S Queue
 - 標準出力ファイル名：run.sh.o12345
 - 標準エラー出力ファイル名：run.sh.e12345
 
-また、出力ファイルはジョブ終了後に作成されます。
 
 ## 環境変数 {#environment-variables}
 
@@ -427,6 +427,17 @@ R1234.pbs1      R1234         usrname  RN            Wed 10:40 / 1506000 / Sat F
 | Start | 予約開始日 (予約開始時刻は常に午前10時) |
 | Duration | 予約期間 (秒) |
 | End | 予約終了日 (予約終了時刻は常に午前9時30分) |
+
+グループあたりの予約可能ノード数を確認するには、`qrstat`コマンドの`--available=grpname`オプションに所属グループ名を指定し、実行します。
+
+例)予約可能ノード数の確認
+```
+[username@login1 ~]$ qrstat --available=grpname
+date       available nodes for group
+---------- -------------------------
+01/30/2025                       192
+01/31/2025                       192
+```
 
 ### 予約の取り消し {#cancel-a-reservation}
 


### PR DESCRIPTION
以下の点を更新するためのPRです。

- SSHでインタラクティブノードにログインする際のローカルポートを50022に記載変更（ABCI 2.0と同じポート10022を指定してしまいアクセスに失敗するお問い合わせを頂いたため）
- qrstat --available=grpnameオプションの追記